### PR TITLE
Unify result limits

### DIFF
--- a/src/command/query.rs
+++ b/src/command/query.rs
@@ -40,7 +40,7 @@ fn query_graylog(
     let mut params = HashMap::new();
     graylog::assign_query(&query, &mut params);
 
-    params.insert("limit", "0".into());
+    params.insert("limit", "10000".into());
     params.insert("from", from);
     params.insert("to", to);
 


### PR DESCRIPTION
Setting the same result limit for graylog queries then elastic (10000). 

/relates to #6 

- according to testing graylog defaults to 150 entries if limit is not set or 0.