### PR TITLE
Add docker test-environment for graylog with opensearch.

### DIFF
--- a/test-envs/elastic/.env
+++ b/test-envs/elastic/.env
@@ -1,0 +1,1 @@
+ELASTIC_PASSWORD="elastic"

--- a/test-envs/elastic/docker-compose.yml
+++ b/test-envs/elastic/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+services:
+  elasticsearch:
+    image: elasticsearch:8.2.2
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      - xpack.security.enabled=false
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    ports:
+      - target: 9200
+        published: 9200
+    networks:
+      - elastic
+
+  kibana:
+    image: kibana:8.2.2
+    ports:
+      - target: 5601
+        published: 5601
+    depends_on:
+      - elasticsearch
+    networks:
+      - elastic      
+
+volumes:
+  es_data:
+    driver: local
+
+networks:
+  elastic:
+    name: elastic
+    driver: bridge

--- a/test-envs/elastic/insert_docs.sh
+++ b/test-envs/elastic/insert_docs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -
+
+echo  "insert 10000 test docs..."
+for i in {0..10000}
+do
+  curl --location --request POST 'http://localhost:9200/testidx/_doc/?pretty' \
+  --header 'Content-Type: application/json' \
+  --data-raw "{
+      \"msg\": \"msg$i\"
+  }"
+done
+echo "done."
+

--- a/test-envs/graylog/.env
+++ b/test-envs/graylog/.env
@@ -1,0 +1,15 @@
+# You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
+# Generate one by using for example: pwgen -N 1 -s 96
+# ATTENTION: This value must be the same on all Graylog nodes in the cluster.
+# Changing this value after installation will render all user sessions and encrypted values in the database invalid. (e.g. encrypted access tokens)
+GRAYLOG_PASSWORD_SECRET="testsecrettestsecrettestsecrettestsecret"
+
+# You MUST specify a hash password for the root user (which you only need to initially set up the
+# system and in case you lose connectivity to your authentication backend)
+# This password cannot be changed using the API or via the web interface. If you need to change it,
+# modify it in this file.
+# Create one by using for example: echo -n yourpassword | shasum -a 256
+# and put the resulting hash value into the following line
+# CHANGE THIS!
+# root user credentials are 'admin' and the hash below is his password 'testsecret'
+GRAYLOG_ROOT_PASSWORD_SHA2="59953998e54a579be74c1b7344cd55c64981451b066a35c9d7baf5497f16d865"

--- a/test-envs/graylog/README.md
+++ b/test-envs/graylog/README.md
@@ -1,0 +1,7 @@
+This meant to be a simple docker based test environment template for graylog (latest configured with opensearch instead of elasticsearch) 
+*Prerequistes* are: `docker`/`docker-compose`, `bash` and `nc`
+
+# Steps to start
+1. cd into test-env graylog directory
+1. `docker compose up`
+1. run `./create_input_and_insert_data.sh` which create a raw tcp input in graylog listening on port 5555 and pushes 10000 sample messages into it via nc

--- a/test-envs/graylog/create_input_and_insert_data.sh
+++ b/test-envs/graylog/create_input_and_insert_data.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -
+
+echo "creating raw input on tcp/5555..."
+curl -u admin:testsecret -H "X-Requested-By: initscript" --header "Content-Type: application/json" \
+  --request POST \
+  --data '{ "title": "rrr", "global": true, "type": "org.graylog2.inputs.raw.tcp.RawTCPInput", "configuration": { "tcp_keepalive": false,  "use_null_delimiter": false,  "tls_client_auth_cert_file": "",  "bind_address": "0.0.0.0",  "tls_cert_file": "",  "port": 5555,  "tls_key_file": "",  "tls_enable": false,  "tls_key_password": "",  "tls_client_auth": "disabled",  "charset_name": "UTF-8"} }' \
+  http://localhost:9000/api/system/inputs 
+echo "done."
+
+echo  "generating 10000 test messages..."
+for i in {0..10000}
+do
+  echo "Msg: $i" | nc -N localhost 5555
+done
+echo "done."
+

--- a/test-envs/graylog/docker-compose.yml
+++ b/test-envs/graylog/docker-compose.yml
@@ -1,0 +1,71 @@
+version: "3.8"
+
+services:
+  mongodb:
+    image: "mongo:5.0"
+    volumes:
+      - "mongodb_data:/data/db"
+    restart: "on-failure"
+
+  opensearch:
+    image: "opensearchproject/opensearch:2.4.0"
+    environment:
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g -Djava.net.preferIPv4Stack=true"
+      - "bootstrap.memory_lock=true"
+      - "discovery.type=single-node"
+      - "action.auto_create_index=false"
+      - "plugins.security.ssl.http.enabled=false"
+      - "plugins.security.disabled=true"
+      - "http.host=0.0.0.0"
+      - "transport.host=localhost"
+      - "network.host=0.0.0.0"
+    ulimits:
+      memlock:
+        hard: -1
+        soft: -1
+    volumes:
+      - "os_data:/usr/share/opensearch/data"
+    restart: "on-failure"
+
+  graylog:
+    hostname: "server"
+    image: "${GRAYLOG_IMAGE:-graylog/graylog:5.0}"
+    depends_on:
+      opensearch:
+        condition: "service_started"
+      mongodb:
+        condition: "service_started"
+    entrypoint: "/usr/bin/tini -- wait-for-it opensearch:9200 --  /docker-entrypoint.sh"
+    environment:
+      GRAYLOG_NODE_ID_FILE: "/usr/share/graylog/data/config/node-id"
+      GRAYLOG_PASSWORD_SECRET: "${GRAYLOG_PASSWORD_SECRET:?Please configure GRAYLOG_PASSWORD_SECRET in the .env file}"
+      GRAYLOG_ROOT_PASSWORD_SHA2: "${GRAYLOG_ROOT_PASSWORD_SHA2:?Please configure GRAYLOG_ROOT_PASSWORD_SHA2 in the .env file}"
+      GRAYLOG_HTTP_BIND_ADDRESS: "0.0.0.0:9000"
+      GRAYLOG_HTTP_EXTERNAL_URI: "http://localhost:9000/"
+      GRAYLOG_ELASTICSEARCH_HOSTS: "http://opensearch:9200"
+      GRAYLOG_MONGODB_URI: "mongodb://mongodb:27017/graylog"
+      GRAYLOG_HTTP_ENABLE_CORS: true
+      GRAYLOG_SERVER_JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
+    ports:
+    - "5044:5044/tcp"   # Beats
+    - "5140:5140/udp"   # Syslog
+    - "5140:5140/tcp"   # Syslog
+    - "5555:5555/tcp"   # RAW TCP
+    - "5555:5555/udp"   # RAW TCP
+    - "9000:9000/tcp"   # Server API
+    - "12201:12201/tcp" # GELF TCP
+    - "12201:12201/udp" # GELF UDP
+    #- "10000:10000/tcp" # Custom TCP port
+    #- "10000:10000/udp" # Custom UDP port
+    - "13301:13301/tcp" # Forwarder data
+    - "13302:13302/tcp" # Forwarder config
+    volumes:
+      - "graylog_data:/usr/share/graylog/data/data"
+      - "graylog_journal:/usr/share/graylog/data/journal"
+    restart: "no"
+
+volumes:
+  mongodb_data:
+  os_data:
+  graylog_data:
+  graylog_journal:

--- a/test-envs/graylog/docker-compose.yml
+++ b/test-envs/graylog/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 
 services:
   mongodb:


### PR DESCRIPTION
Just for convenience this is a test environment one can use to test graylog on local development machine. Maybe it is good to have for later testing as well?!